### PR TITLE
Update Dockerfile: reduce intermediate images, use system packages, r…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,23 +3,27 @@ FROM ubuntu:latest
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Istanbul
 
-# Gather dependencies
-RUN apt update && apt install -y curl wget git binutils sudo unzip python3 python3-pip mono-complete default-jre
-RUN pip3 install setuptools wheel pythonnet pycryptodome python-magic
-
 # Install application
 WORKDIR /app
 COPY . .
 
-# Configuration
-RUN chmod +x qu1cksc0pe.py setup.sh
-RUN ln -s /root /home/root
-RUN ./setup.sh
-RUN wget https://raw.githubusercontent.com/CYB3RMX/MalwareHashDB/main/HashDB -O /home/root/sc0pe_Base/HashDB
+# Gather dependencies
+RUN apt update && \
+apt install -y curl wget git binutils sudo unzip python3 python3-pip python3-setuptools python3-wheel python3-pycryptodome python3-magic dos2unix mono-complete default-jre adb && \
+apt clean && \
+useradd -m -s /bin/bash quickscope
 
-# Cleanup
-RUN apt clean
+USER quickscope
+WORKDIR /home/quickscope
+
+RUN git clone https://github.com/CYB3RMX/Qu1cksc0pe.git app && \
+find app -type f -exec dos2unix {} \; && \
+cd app && \
+# Configuration
+chmod 755 qu1cksc0pe.py setup.sh && \
+./setup.sh && \
+wget https://raw.githubusercontent.com/CYB3RMX/MalwareHashDB/main/HashDB -O /home/quickscope/sc0pe_Base/HashDB
 
 # RE-Enter app directory
-WORKDIR /app
-ENTRYPOINT ["/app/qu1cksc0pe.py"]
+WORKDIR /home/quickscope/app
+ENTRYPOINT ["/home/quickscope/app/qu1cksc0pe.py"]


### PR DESCRIPTION
I rewrote the Dockerfile to reduce the number of intermediate images.
It also uses more system packages (python3-setuptools python3-wheel python3-pycryptodome python3-magic) and installs packages that setup.sh would install.
It installs the app from git in user directory and run it as the user.