### PR TITLE
Introduce a proper entrypoint

### DIFF
--- a/qu1cksc0pe.py
+++ b/qu1cksc0pe.py
@@ -437,10 +437,16 @@ def cleanup_junks():
             else:
                 os.system(f"powershell -c \"del {junk} -Force -Recurse\"")
 
-# Exectuion area
-try:
-    Qu1cksc0pe()
-    # Cleaning up...
-    cleanup_junks()
-except:
-    cleanup_junks()
+def main():
+    try:
+        Qu1cksc0pe()
+        # Cleaning up...
+        cleanup_junks()
+    except:
+        cleanup_junks()
+
+
+# This is the entrypoint when directly running this module
+# as a standalone module (as opposed to a lib)
+if __name__ == "__main__":
+    main()

--- a/qu1cksc0pe.py
+++ b/qu1cksc0pe.py
@@ -446,7 +446,8 @@ def main():
         cleanup_junks()
 
 
-# This is the entrypoint when directly running this module
-# as a standalone module (as opposed to a lib)
+# This is the entrypoint when directly running
+# this module as a standalone program
+# (as opposed to it being imported/ran like a lib)
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
It's generally preferred to have a main function which is then "registered" to run only if the program is executed directly (over putting code straight into the uppermost scope to run unconditionally when the module is invoked/loaded).

This is not only a Python convention but also makes the programs functionality/sub-modules available for people to import without forcing an execution of the entire thing.