### PR TITLE
Avoid unicode NULL chars in JSON report file (linux analyzer)

### DIFF
--- a/Modules/linAnalyzer.py
+++ b/Modules/linAnalyzer.py
@@ -77,7 +77,7 @@ class LinuxAnalyzer:
 
     def parse_section_content(self, sec_name):
         return "".join([chr(unicode_point)
-            for unicode_point in self.binary.get_section(sec_name).content])
+            for unicode_point in self.binary.get_section(sec_name).content if unicode_point != 0])
 
     def check_bin_security(self):
         binsec_t = init_table("[bold yellow]NX", "[bold yellow]PIE", title="* Security *")


### PR DESCRIPTION
from #58:
> regarding the Unicode Null character `\u0000` in the interpreter value: [...] My best guess is that it stems either from an error/issue internal to lief.parse or more likely a usage error in the way we call chr on the result of `self.binary.get_section(sec_name).content` [...] I'll open a small followup PR for that after this one gets merged.[^1]

this should fix it.

[^1]: https://github.com/CYB3RMX/Qu1cksc0pe/pull/58#issuecomment-2218492927