### PR TITLE
Make console prompt acceptance evaluation more flexible

### DIFF
--- a/Modules/utils.py
+++ b/Modules/utils.py
@@ -61,10 +61,13 @@ def init_table(*col_names, style=None, col_prefix="", justify="center", **title_
 def no_blanks(str_li):
     return (x for x in str_li if len(x.strip()) > 0)
 
-def user_confirm(question_text):
-    return str(
-        input(question_text)
-    ).lstrip().lower().startswith("y")
+def user_confirm(question_text, strict=False):
+    if strict:
+        return str(input(question_text)).lower() == "y"
+    else:
+        return str(
+            input(question_text)
+        ).lstrip().lower().startswith("y")
 
 def stylize_bool(b, invert_style=False):
     prefix = "[bold green]" if b ^ invert_style else "[bold red]"

--- a/Modules/utils.py
+++ b/Modules/utils.py
@@ -62,7 +62,9 @@ def no_blanks(str_li):
     return (x for x in str_li if len(x.strip()) > 0)
 
 def user_confirm(question_text):
-    return str(input(question_text)).lower() == "y"
+    return str(
+        input(question_text)
+    ).lstrip().lower().startswith("y")
 
 def stylize_bool(b, invert_style=False):
     prefix = "[bold green]" if b ^ invert_style else "[bold red]"


### PR DESCRIPTION
a tiny change, albeit quite nice to have IMO:

Currently, we only consider either `y` or `Y` affirmative responses.
It might be nice for convenience to also accept "non-standard" answers, such as `yes`, `yeah` etc, anything starting with `y` after transforming to lowercase, you get the point.


While we're at it, we should also ignore whitespace.

Since the functionality for the prompts is now located at a shared, centralized location we can easily afford this change without much effort and have it apply consitently for all confirmation prompts to the user.

If you @CYB3RMX think this is too fuzzy & dumb don't worry, you can just reject & close it, it's just an idea (: