### PR TITLE
Introduce preliminary integration testing helper script (hardcoded to linux analyzer only for now)

### DIFF
--- a/Tests/base_cmp_stdout.sh
+++ b/Tests/base_cmp_stdout.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+
+# [ARRANGE]
+# TODO consider `git branch --show-current` instead
+# but requires newer git version AFAIK (on top of not working for submodules)
+branch_to_test=$(git symbolic-ref --short HEAD)
+test_output_file="./current.stdout.txt"
+baseline_output_file="./baseline.stdout.txt"
+# TODO parameterize the actual invocation that gets compared, either via config or cmd line args
+# (consider directly controlling the invocation target(s) via pipeline vars once this runs as a proper CI job)
+# (either directly inline via token replacement or via ENV vars set by the job which just get read by this script)
+# (this way we wouldn't have to process command line args here and could still dynamically determine
+# execution targets based on which analyzers were modified)
+# (then the parts below would have to be looped for each module to be tested OR just loop the whole script instead?)
+# TODO currently this only tests the linux analyzer
+
+# [ACT]
+echo "[INFO] Running a test analysis on the current branch and redirecting output to [${test_output_file}]"
+python3 ./qu1cksc0pe.py --file /usr/bin/ls --analyze --no_banner > ${test_output_file}
+echo "[INFO] Switching to master branch"
+git checkout master
+echo "[INFO] Running a test analysis on master for baseline output, redirecting to [${baseline_output_file}]"
+python3 ./qu1cksc0pe.py --file /usr/bin/ls --analyze --no_banner > ${baseline_output_file}
+
+# [ASSERT]
+# TODO also diff any report files that might be present?
+result=$(diff --text --ignore-all-space ${baseline_output_file} ${test_output_file})
+if [ ${#result} -eq 0 ]
+then
+  echo "[INFO] test successful, found no diff!"
+else
+  echo "[FAILURE] the test output does NOT match the baseline:"
+  echo "${result}"
+  echo "[INFO] total diff size: ${#result}"
+  exit 1
+fi
+
+# [CLEANUP]
+echo "[INFO] Cleaning up test artifacts"
+rm ${test_output_file}
+rm ${baseline_output_file}
+echo "[INFO] Switching back to branch: [${branch_to_test}]"
+git checkout ${branch_to_test}
+
+
+echo "[INFO] Here's git status:"
+git status

--- a/qu1cksc0pe.py
+++ b/qu1cksc0pe.py
@@ -112,8 +112,6 @@ def execute_module(target, path=MODULE_PREFIX, invoker=py_binary):
 
     os.system(f"{invoker} {path}{target}")
 
-import Modules.banners # show a banner
-
 # Argument crating, parsing and handling
 ARG_NAMES_TO_KWARG_OPTS = {
     "file": {"help": "Specify a file to scan or analyze."},
@@ -134,8 +132,12 @@ ARG_NAMES_TO_KWARG_OPTS = {
     "report": {"help": "Export analysis reports into a file (JSON Format for now).", "action": "store_true"},
     "watch": {"help": "Perform dynamic analysis against Windows/Android files. (Linux will coming soon!!)", "action": "store_true"},
     "sigcheck": {"help": "Scan file signatures in target file.", "action": "store_true"},
-    "vtFile": {"help": "Scan your file with VirusTotal API.", "action": "store_true"}
+    "vtFile": {"help": "Scan your file with VirusTotal API.", "action": "store_true"},
+    "no_banner": {"help": "Launch Qu1cksc0pe without showing a banner.", "action": "store_true"}
 }
+
+if not args.no_banner:
+    import Modules.banners # show a banner
 
 parser = argparse.ArgumentParser()
 for arg_name, cfg in ARG_NAMES_TO_KWARG_OPTS.items():

--- a/qu1cksc0pe.py
+++ b/qu1cksc0pe.py
@@ -136,14 +136,14 @@ ARG_NAMES_TO_KWARG_OPTS = {
     "no_banner": {"help": "Launch Qu1cksc0pe without showing a banner.", "action": "store_true"}
 }
 
-if not args.no_banner:
-    import Modules.banners # show a banner
-
 parser = argparse.ArgumentParser()
 for arg_name, cfg in ARG_NAMES_TO_KWARG_OPTS.items():
     cfg["required"] = cfg.get("required", False)
     parser.add_argument("--" + arg_name, **cfg)
 args = parser.parse_args()
+
+if not args.no_banner:
+    import Modules.banners # show a banner
 
 # Basic analyzer function that handles single and multiple scans
 def BasicAnalyzer(analyzeFile):


### PR DESCRIPTION
Hello, Friend

this script constitutes the first, tiny step towards automated testing.

This relates to the integration testing part of #60 (see that issue for a broader overview/more details in terms of ideas).

In the future, an improved, parameterized version of this script will be ran autmatically as a CI job to verify pull requests as soon as they are submitted (if you'd like that). For now, it just exists as a basic version we/I can improve later and to help a tiny bit with manual testing.

> [!NOTE]
> - since the `no_banner` option isn't present on `master` yet, the script will fail to run properly if you try it out right now as is
> - for now, it still needs to be copied from the new "Tests" directory to the root of the repo before being executed
>   - I think that's ok for now, I'll see how I handle paths down the line once this gets further/fully automated