### PR TITLE
Fix #66 - Replace distutils.spawn.find_executable with shutil.which

### DIFF
--- a/Modules/android_dynamic_analyzer.py
+++ b/Modules/android_dynamic_analyzer.py
@@ -9,7 +9,7 @@ import warnings
 import threading
 import subprocess
 import configparser
-import distutils.spawn
+import shutil
 
 from utils import err_exit, user_confirm
 
@@ -48,7 +48,7 @@ homeD = os.path.expanduser("~")
 path_seperator = "/"
 setup_scr = "setup.sh"
 strings_param = "--all"
-adb_path = distutils.spawn.find_executable("adb")
+adb_path = shutil.which("adb")
 del_com = "rm -rf"
 if sys.platform == "win32":
     path_seperator = "\\"

--- a/Modules/apkAnalyzer.py
+++ b/Modules/apkAnalyzer.py
@@ -9,7 +9,7 @@ import getpass
 import configparser
 import requests
 import subprocess
-import distutils.spawn
+import shutil
 from datetime import date
 
 from utils import err_exit
@@ -52,7 +52,7 @@ foundS = f"[bold cyan][[bold red]+[bold cyan]][white]"
 errorS = f"[bold cyan][[bold red]![bold cyan]][white]"
 
 # Get python binary
-if distutils.spawn.find_executable("python"):
+if shutil.which("python"):
     py_binary = "python"
 else:
     py_binary = "python3"

--- a/Modules/console.py
+++ b/Modules/console.py
@@ -2,7 +2,7 @@
 
 import os
 import sys
-import distutils.spawn
+import shutil
 import subprocess
 
 from utils import err_exit
@@ -53,7 +53,7 @@ errorS = f"[bold cyan][[bold red]![bold cyan]][white]"
 sc0pe_path = open(".path_handler", "r").read()
 
 # Get python binary
-if distutils.spawn.find_executable("python"):
+if shutil.which("python"):
     py_binary = "python"
 else:
     py_binary = "python3"
@@ -193,7 +193,7 @@ try:
                 print(f"\n{infoS} Analyzing: [bold green]{filename}[white]")
                 fileType = str(pr.magic_file(filename))
                 if "ELF" in fileType:
-                    if distutils.spawn.find_executable("strings"):
+                    if shutil.which("strings"):
                         str_proc = subprocess.run(f"strings {strings_param} \"{filename}\" > temp.txt", stderr=subprocess.PIPE, stdout=subprocess.PIPE, stdin=subprocess.PIPE, shell=True)
                         print(f"{infoS} Target OS: [bold green]Linux[white]\n")
                         command = f"{py_binary} {sc0pe_path}{path_seperator}Modules{path_seperator}linAnalyzer.py \"{filename}\""
@@ -211,7 +211,7 @@ try:
                 print(f"\n{infoS} Analyzing: [bold green]{filename}[white]")
                 fileType = str(pr.magic_file(filename))
                 if "Mach-O" in fileType:
-                    if distutils.spawn.find_executable("strings"):
+                    if shutil.which("strings"):
                         str_proc = subprocess.run(f"strings {strings_param} \"{filename}\" > temp.txt", stderr=subprocess.PIPE, stdout=subprocess.PIPE, stdin=subprocess.PIPE, shell=True)
                         print(f"{infoS} Target OS: [bold green]OSX[white]\n")
                         command = f"{py_binary} {sc0pe_path}{path_seperator}Modules{path_seperator}apple_analyzer.py \"{filename}\""
@@ -231,7 +231,7 @@ try:
                 if "PK" in fileType and "Java archive" in fileType:
                     look = pyaxmlparser.APK(filename)
                     if look.is_valid_APK() == True:
-                        if distutils.spawn.find_executable("strings"):
+                        if shutil.which("strings"):
                             str_proc = subprocess.run(f"strings {strings_param} \"{filename}\" > temp.txt", stderr=subprocess.PIPE, stdout=subprocess.PIPE, stdin=subprocess.PIPE, shell=True)
                             print(f"{infoS} Target OS: [bold green]Android[white]")    
                             command = f"{py_binary} {sc0pe_path}{path_seperator}Modules{path_seperator}apkAnalyzer.py \"{filename}\""
@@ -258,7 +258,7 @@ try:
         elif con_command == "domain":
             if os.path.exists(".target-file.txt"):
                 filename = open(".target-file.txt", "r").read()
-                if distutils.spawn.find_executable("strings"):
+                if shutil.which("strings"):
                     str_proc = subprocess.run(f"strings {strings_param} \"{filename}\" > temp.txt", stderr=subprocess.PIPE, stdout=subprocess.PIPE, stdin=subprocess.PIPE, shell=True)
                     command = f"{py_binary} {sc0pe_path}{path_seperator}Modules{path_seperator}domainCatcher.py \"{filename}\""
                     os.system(command)
@@ -272,7 +272,7 @@ try:
         elif con_command == "language":
             if os.path.exists(".target-file.txt"):
                 filename = open(".target-file.txt", "r").read()
-                if distutils.spawn.find_executable("strings"):
+                if shutil.which("strings"):
                     str_proc = subprocess.run(f"strings {strings_param} \"{filename}\" > temp.txt", stderr=subprocess.PIPE, stdout=subprocess.PIPE, stdin=subprocess.PIPE, shell=True)
                     command = f"{py_binary} {sc0pe_path}{path_seperator}Modules{path_seperator}languageDetect.py \"{filename}\""
                     os.system(command)

--- a/Modules/email_analyzer.py
+++ b/Modules/email_analyzer.py
@@ -5,7 +5,7 @@ import re
 import sys
 import email
 import subprocess
-import distutils.spawn
+import shutil
 
 from utils import err_exit
 
@@ -26,7 +26,7 @@ infoS = f"[bold cyan][[bold red]*[bold cyan]][white]"
 errorS = f"[bold cyan][[bold red]![bold cyan]][white]"
 
 # Get python binary
-if distutils.spawn.find_executable("python"):
+if shutil.which("python"):
     py_binary = "python"
 else:
     py_binary = "python3"

--- a/Modules/emulator.py
+++ b/Modules/emulator.py
@@ -2,7 +2,7 @@
 
 import os
 import sys
-import distutils.spawn
+import shutil
 
 from utils import err_exit
 
@@ -33,7 +33,7 @@ infoS = f"[bold cyan][[bold red]*[bold cyan]][white]"
 infoC = f"{cyan}[{red}*{cyan}]{white}"
 
 # Get python binary
-if distutils.spawn.find_executable("python"):
+if shutil.which("python"):
     py_binary = "python"
 else:
     py_binary = "python3"

--- a/Modules/pcap_analyzer.py
+++ b/Modules/pcap_analyzer.py
@@ -5,7 +5,7 @@ import os
 import sys
 import json
 import binascii
-import distutils.spawn
+import shutil
 
 from utils import err_exit, user_confirm
 
@@ -25,13 +25,13 @@ except:
 infoS = f"[bold cyan][[bold red]*[bold cyan]][white]"
 errorS = f"[bold cyan][[bold red]![bold cyan]][white]"
 
-if not distutils.spawn.find_executable("ja3"):
+if not shutil.which("ja3"):
     print(f"{errorS} Error: [bold green]ja3[white] command not found!")
     print(f"[bold red]>>>[white] Execute: [bold green]pip3 install pyja3[white]")
     sys.exit(1)
 
 # Get python binary
-if distutils.spawn.find_executable("python"):
+if shutil.which("python"):
     py_binary = "python"
 else:
     py_binary = "python3"

--- a/qu1cksc0pe.py
+++ b/qu1cksc0pe.py
@@ -7,7 +7,6 @@ try:
     import argparse
     import getpass
     import configparser
-    import distutils.spawn
     import shutil
     import warnings
 except Exception as e:
@@ -55,7 +54,7 @@ errorS = f"[bold cyan][[bold red]![bold cyan]][white]"
 username = getpass.getuser()
 
 # Get python binary
-if distutils.spawn.find_executable("python"):
+if shutil.which("python"):
     py_binary = "python"
 else:
     py_binary = "python3"
@@ -207,7 +206,7 @@ def Qu1cksc0pe():
             # Before doing something we need to check file size
             file_size = os.path.getsize(args.file)
             if file_size < 52428800: # If given file smaller than 100MB
-                if not distutils.spawn.find_executable("strings"):
+                if not shutil.which("strings"):
                     err_exit("[bold white on red][blink]strings[/blink] command not found. You need to install it.")
             else:
                 print(f"{infoS} Whoa!! Looks like we have a large file here.")


### PR DESCRIPTION
`distutils.spawn.find_executable` is deprecated because `distutils` is gone in Python >= 3.12.

However, this is basically the same functionality of `shutil.which`, and as we already import `shutil` in numerous places, just use that instead of `distutils`.

Fixes #66 