### PR TITLE
Fix lief 0.13.2 error during pip install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ pyaxmlparser
 yara-python==4.5.0
 prompt_toolkit==3.0.43
 frida-tools
-lief==0.13.2
+lief>=0.13.2
 pygore
 pdfminer.six
 requests


### PR DESCRIPTION
It fixes the error during the python deps install:
```
ERROR: Could not find a version that satisfies the requirement lief==0.13.2 (from versions: 0.8.0.post7, 0.8.1.post1, 0.8.2.post1, 0.8.3.post3, 0.9.0, 0.10.0, 0.10.1, 0.11.0, 0.11.1, 0.11.2, 0.11.3, 0.11.4, 0.11.5, 0.12.0, 0.12.1, 0.12.2, 0.12.3, 0.14.0, 0.14.1, 0.15.0, 0.15.1)

[notice] A new release of pip is available: 24.2 -> 24.3.1
[notice] To update, run: pip install --upgrade pip
ERROR: No matching distribution found for lief==0.13.2
```