### PR TITLE
Running --analyze with Docker container setup produce error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Istanbul
 
 # Gather dependencies
-RUN apt update && apt install -y curl wget git binutils sudo unzip python3 python3-pip default-jre
+RUN apt update && apt install -y curl wget git binutils sudo unzip python3 python3-pip default-jre file
 RUN pip3 install setuptools wheel
 
 # Install application


### PR DESCRIPTION
Hello,

Just saw that `--analyze` was broken when using Qu1cksc0pe with Docker; due to missing `file` package on the container image.


With original Dockerfile:
<img width="1318" height="797" alt="image" src="https://github.com/user-attachments/assets/22b679bf-0637-4b50-aa53-0f61c3da63eb" />

With the fixed one:
<img width="1522" height="1023" alt="image" src="https://github.com/user-attachments/assets/90a36f4c-e128-4790-9298-b7b3b35f19e5" />
